### PR TITLE
Migrate from kotlin synthetics

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,22 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,15 +2,13 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.example.hands_onlab"
         minSdkVersion 28
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -35,7 +33,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/app/src/main/java/com/example/hands_onlab/MainActivity.kt
+++ b/app/src/main/java/com/example/hands_onlab/MainActivity.kt
@@ -5,7 +5,7 @@ import android.text.method.ScrollingMovementMethod
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
-import kotlinx.android.synthetic.main.activity_main.*
+import com.example.hands_onlab.databinding.ActivityMainBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,9 +17,11 @@ import kotlin.coroutines.CoroutineContext
 
 
 class MainActivity : AppCompatActivity(), CoroutineScope {
+    private lateinit var binding: ActivityMainBinding
     private var job: Job = Job()
+
     override val coroutineContext: CoroutineContext
-    get() = Dispatchers.Main + job
+        get() = Dispatchers.Main + job
 
     val service: HttpBinAPI by lazy {
         val retrofit = Retrofit.Builder()
@@ -32,26 +34,26 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
         retrofit.create(HttpBinAPI::class.java)
     }
 
-//    private lateinit var binding: ActivityMainBinding
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-//        binding = ActivityMainBinding.inflate(layoutInflater)
-//        setContentView(binding.root)
+
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
         setUpUi()
     }
 
     private fun setUpUi() {
         //set scrolling
-        responseText.movementMethod = ScrollingMovementMethod()
+        binding.responseText.movementMethod = ScrollingMovementMethod()
         // Button methods
-        getButton.setOnClickListener { launch { getButton() } }
-        postButton.setOnClickListener { launch { postButton() } }
-        putButton.setOnClickListener { launch { putButton() } }
-        deleteButton.setOnClickListener { launch { deleteButton() } }
-        downloadButton.setOnClickListener { launch { downloadButton() } }
-        errorButton.setOnClickListener { launch { errorButton() } }
+        binding.getButton.setOnClickListener { launch { getButton() } }
+        binding.postButton.setOnClickListener { launch { postButton() } }
+        binding.putButton.setOnClickListener { launch { putButton() } }
+        binding.deleteButton.setOnClickListener { launch { deleteButton() } }
+        binding.downloadButton.setOnClickListener { launch { downloadButton() } }
+        binding.errorButton.setOnClickListener { launch { errorButton() } }
     }
 
     override fun onDestroy() {
@@ -59,39 +61,40 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
         job.cancel()
     }
 
-    private suspend fun getButton(){
+    private suspend fun getButton() {
         val response = service.getButton().await()
-        responseText.text = "Get Response : \n${response.body()}"
+        binding.responseText.text = "Get Response : \n${response.body()}"
         Toast.makeText(this, "Get Button clicked", Toast.LENGTH_SHORT).show()
     }
 
-    private suspend fun postButton(){
+    private suspend fun postButton() {
         val response = service.postButton(body = PostBody()).await()
-        responseText.text = "Post Response :\n${response.body()}"
+        binding.responseText.text = "Post Response :\n${response.body()}"
         Toast.makeText(this, "Post Button clicked", Toast.LENGTH_SHORT).show()
     }
 
-    private suspend fun putButton(){
-        val response = service.putButton(body = PostBody(name = "larry",job = "bobo")).await()
-        responseText.text = "Put Response :\n${response.body()}"
+    private suspend fun putButton() {
+        val response = service.putButton(body = PostBody(name = "larry", job = "bobo")).await()
+        binding.responseText.text = "Put Response :\n${response.body()}"
         Toast.makeText(this, "Put Button clicked", Toast.LENGTH_SHORT).show()
     }
 
-    private suspend fun deleteButton(){
+    private suspend fun deleteButton() {
         val response = service.deleteButton().await()
-        responseText.text = "Delete Response :\n${response.body()}"
+        binding.responseText.text = "Delete Response :\n${response.body()}"
         Toast.makeText(this, "Delete Button clicked", Toast.LENGTH_SHORT).show()
     }
 
-    private suspend fun downloadButton(){
+    private suspend fun downloadButton() {
         val response = service.downloadButton().await()
-        responseText.text = "Download Response :\n${response.body()}"
+        binding.responseText.text = "Download Response :\n${response.body()}"
         Toast.makeText(this, "Download Button clicked", Toast.LENGTH_SHORT).show()
     }
 
-    private suspend fun errorButton(){
+    private suspend fun errorButton() {
         val response = service.errorButton().await()
-        responseText.text = "Error Response : \n${response.errorBody()?.string() ?: "there is no errorBody string"}"
+        binding.responseText.text =
+            "Error Response : \n${response.errorBody()?.string() ?: "there is no errorBody string"}"
         Toast.makeText(this, "Error Button clicked", Toast.LENGTH_SHORT).show()
 
         val num1 = 0
@@ -101,7 +104,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
             val result = num2 / num1
 
         } catch (e: Exception) {
-            val attributesMap = mapOf<String, Any>(Pair("num1",num1),Pair("num2",num2))
+            val attributesMap = mapOf<String, Any>(Pair("num1", num1), Pair("num2", num2))
             Toast.makeText(this, "num1: " + num1 + " num2: " + num2, Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/com/example/hands_onlab/MainActivity.kt
+++ b/app/src/main/java/com/example/hands_onlab/MainActivity.kt
@@ -32,9 +32,13 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
         retrofit.create(HttpBinAPI::class.java)
     }
 
+//    private lateinit var binding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+//        binding = ActivityMainBinding.inflate(layoutInflater)
+//        setContentView(binding.root)
         setUpUi()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
@@ -19,7 +19,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+
     }
 }
 


### PR DESCRIPTION
View Binding is now the recommended way of getting references to views:
https://developer.android.com/topic/libraries/view-binding/

Migrated to View Binding and removed all references via `kotlinx.android.synthetic` imports

`compileSdkVersion` and `targetSdkVersion` versions were updated from 29 to 30

Minor code format changes

